### PR TITLE
Param index fix

### DIFF
--- a/lib/languages/SQLServer.js
+++ b/lib/languages/SQLServer.js
@@ -12,7 +12,7 @@ module.exports = function(sql) {
 	sql.transformValueResult = function(valuesAsArray) {
 		let resultAsObj = {}
 		sql.forEach(valuesAsArray, (value, index) => {
-			resultAsObj['param' + index] = value
+			resultAsObj['param' + (index + 1)] = value
 		});
 		return resultAsObj;
 	}


### PR DESCRIPTION
In SQLServer language the params where created in 0 based index and params in result query where created with 1 based index, so anytime that I tried to create a query for SQLServer it crashed because it can never figure out the last parameter, example: i had 14 params (param1, param2,..., param14) in query and in values array I had param0 to param13, so param14 can never be figured out. Thats why i just incremented value array index in 1, to solve this error.